### PR TITLE
style: cve: add length limits to description field

### DIFF
--- a/app/form/cve.py
+++ b/app/form/cve.py
@@ -1,14 +1,15 @@
 from .base import BaseForm
 from wtforms import StringField, SelectField, TextAreaField, SubmitField
-from wtforms.validators import DataRequired
+from wtforms.validators import DataRequired, Length, Optional
 from app.form.validators import ValidIssue
+from app.model.cve import CVE
 from app.model.enum import Severity, Remote
 
 
 class CVEForm(BaseForm):
     cve = StringField(u'CVE', validators=[DataRequired(), ValidIssue()])
-    description = TextAreaField(u'Description', validators=[])
+    description = TextAreaField(u'Description', validators=[Optional(), Length(max=CVE.DESCRIPTION_LENGTH)])
     severity = SelectField(u'Severity', choices=[(e.name, e.label) for e in [*Severity]], validators=[])
     remote = SelectField(u'Remote', choices=[(e.name, e.label) for e in [*Remote]], validators=[])
-    notes = TextAreaField(u'Notes', validators=[])
+    notes = TextAreaField(u'Notes', validators=[Length(max=CVE.NOTES_LENGTH)])
     submit = SubmitField(u'submit')

--- a/app/form/group.py
+++ b/app/form/group.py
@@ -1,7 +1,7 @@
 from .base import BaseForm
 from wtforms import StringField, SelectField, TextAreaField, SubmitField
-from wtforms.validators import DataRequired, Optional, Regexp
-from app.model.cvegroup import pkgver_regex
+from wtforms.validators import DataRequired, Optional, Regexp, Length
+from app.model.cvegroup import pkgver_regex, CVEGroup
 from app.model.enum import Affected
 from app.form.validators import ValidPackageNames, SamePackageVersions, ValidIssues
 from pyalpm import vercmp
@@ -16,7 +16,7 @@ class GroupForm(BaseForm):
     fixed = StringField(u'Fixed Version', validators=[Optional(), Regexp(pkgver_regex)])
     status = SelectField(u'Status', choices=[(e.name, e.label) for e in [*Affected]], validators=[DataRequired()])
     bug_ticket = StringField('Bug ticket', validators=[Optional(), Regexp(r'^\d+$')])
-    notes = TextAreaField(u'Notes', validators=[])
+    notes = TextAreaField(u'Notes', validators=[Length(CVEGroup.NOTES_LENGTH)])
     advisory_qualified = SelectField(u'Advisory qualified', choices=[('true', 'Yes'), ('false', 'No')], validators=[DataRequired()])
     submit = SubmitField(u'submit')
 

--- a/app/model/cve.py
+++ b/app/model/cve.py
@@ -6,12 +6,16 @@ cve_id_regex = r'^(CVE\-\d{4}\-\d+)$'
 
 
 class CVE(db.Model):
+
+    NOTES_LENGTH = 4096
+    DESCRIPTION_LENGTH = 4096
+
     __tablename__ = 'cve'
     id = db.Column(db.String(15), index=True, unique=True, primary_key=True)
-    description = db.Column(db.String(4096))
+    description = db.Column(db.String(DESCRIPTION_LENGTH))
     severity = db.Column(Severity.as_type(), nullable=False, default=Severity.unknown)
     remote = db.Column(Remote.as_type(), nullable=False, default=Remote.unknown)
-    notes = db.Column(db.String(4096))
+    notes = db.Column(db.String(NOTES_LENGTH))
 
     def __repr__(self):
         return '{}'.format(self.id)

--- a/app/model/cvegroup.py
+++ b/app/model/cvegroup.py
@@ -9,6 +9,8 @@ vulnerability_group_regex = r'^AVG-\d+$'
 
 
 class CVEGroup(db.Model):
+
+    NOTES_LENGTH = 4096
     __tablename__ = 'cve_group'
     id = db.Column(db.Integer(), index=True, unique=True, primary_key=True, autoincrement=True)
     status = db.Column(Status.as_type(), nullable=False, default=Status.unknown, index=True)
@@ -16,7 +18,7 @@ class CVEGroup(db.Model):
     affected = db.Column(db.String(32), nullable=False)
     fixed = db.Column(db.String(32))
     bug_ticket = db.Column(db.String(9))
-    notes = db.Column(db.String(4096))
+    notes = db.Column(db.String(NOTES_LENGTH))
     created = db.Column(db.DateTime, default=datetime.utcnow, nullable=False, index=True)
     advisory_qualified = db.Column(db.Boolean(), default=True, nullable=False)
 

--- a/app/templates/form/cve.html
+++ b/app/templates/form/cve.html
@@ -6,10 +6,10 @@
         {{ form.hidden_tag() }}
         <dl>
             {{ render_field(form.cve) }}
-            {{ render_field(form.description) }}
+            {{ render_field(form.description, maxlength=CVE.DESCRIPTION_LENGTH) }}
             {{ render_field(form.severity) }}
             {{ render_field(form.remote) }}
-            {{ render_field(form.notes) }}
+            {{ render_field(form.notes, maxlength=CVE.NOTES_LENGTH) }}
             {{ render_field_unlabeled(form.submit, class_='button-primary') }}
         </dl>
     </form>

--- a/app/templates/form/group.html
+++ b/app/templates/form/group.html
@@ -10,7 +10,7 @@
             {{ render_field(form.affected) }}
             {{ render_field(form.fixed) }}
             {{ render_field(form.bug_ticket) }}
-            {{ render_field(form.notes) }}
+            {{ render_field(form.notes, maxlength=CVEGroup.NOTES_LENGTH) }}
             {{ render_field(form.status) }}
             {{ render_field(form.advisory_qualified) }}
             {{ render_field_unlabeled(form.submit, class_='button-primary') }}

--- a/app/view/add.py
+++ b/app/view/add.py
@@ -12,7 +12,8 @@ def add_cve():
     if not form.validate_on_submit():
         return render_template('form/cve.html',
                                title='Add CVE',
-                               form=form)
+                               form=form,
+                               CVE=CVE)
 
     cve = db.get(CVE, id=form.cve.data)
     if cve is not None:
@@ -35,7 +36,8 @@ def add_group():
     if not form.validate_on_submit():
         return render_template('form/group.html',
                                title='Add AVG',
-                               form=form)
+                               form=form,
+                               CVEGroup=CVEGroup)
 
     issues = []
     cve_ids = multiline_to_list(form.cve.data)


### PR DESCRIPTION
Maximum length validation for the description field is done on the
backend. As of now, the application truncates any description that
exceeds 4096 characters. Although this is the right way to ensure no
excess data is given, descriptions may end truncated with prior notice
to the user, which may be undesirable.

Add a maxlength attribute to the textarea field, as well as a validator
for the cve form and form template.