### PR TITLE
app:view:edit: fix wrong CVE list parsing

### DIFF
--- a/app/view/edit.py
+++ b/app/view/edit.py
@@ -99,7 +99,7 @@ def edit_group(avg):
     group.notes = form.notes.data
     group.advisory_qualified = 'true' == form.advisory_qualified.data
 
-    cve_ids = [form.cve.data] if '\r\n' not in form.cve.data else form.cve.data.split('\r\n')
+    cve_ids = multiline_to_list(form.cve.data)
     cve_ids = set(filter(lambda s: s.startswith('CVE-'), cve_ids))
     issues_removed = set(filter(lambda issue: issue not in cve_ids, issue_ids))
     issues_added = set(filter(lambda issue: issue not in issue_ids, cve_ids))


### PR DESCRIPTION
When editing AVG's, the view handler splits the data from the form using
'\r\n'. This allows for the creation of spureous CVE values if two cve's
are input using a space, instead of a new line and carriage return.

Split the CVE field using multiline_to_list. This is the method used for
the add views, and it handles this case properly.

fixes #5 