### PR TITLE
flask_wtf.Form will be deprecated in FlaskWTF 1.0

### DIFF
--- a/app/form/base.py
+++ b/app/form/base.py
@@ -1,7 +1,7 @@
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 
 
-class BaseForm(Form):
+class BaseForm(FlaskForm):
     class Meta:
         def bind_field(self, form, unbound_field, options):
             filters = unbound_field.kwargs.get('filters', [])


### PR DESCRIPTION
"flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in
1.0. 0.13.1 already supports the replacement FlaskForm.

See https://github.com/lepture/flask-wtf/pull/250