### PR TITLE
WIP: Add missing requirements.txt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 app.db
+
+.virtualenv

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ vulnerability details and generating security advisories.
 * sqlite
 * expac
 
+Python dependencies can be installed in a virtual environment (`virtualenv`), by running:
+
+```
+virtualenv .virtualenv
+. .virtualenv/bin/activate
+pip install -r requirements.txt
+```
+
 ## Setup
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask-SQLAlchemy
 Flask-WTF
 requests
 scrypt
+https://git.archlinux.org/users/remy/pyalpm.git/snapshot/pyalpm-0.8.tar.xz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+Flask-Login
+Flask-SQLAlchemy
+Flask-WTF
+requests
+scrypt


### PR DESCRIPTION
In order to more easily track the required dependencies to get the
project up and running, use a `requirements.txt` file.

*Note*: This PR is currently a WIP as it would be good to hear thoughts on the best way to lock down dependencies for `pyalpm`, `sqlite` and `expac`, if possible.